### PR TITLE
fix(readme): fix this.state += 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const wrapComponentWithState = provideState({
   initialState: () => ({ counter: 0 }),
   effects: {
     addOne() {
-      this.state += 1;
+      this.state.counter += 1;
     },
   },
   computed: {


### PR DESCRIPTION
### Description
`this.state += 1` return the following error: `cannot convert object to primitive value`